### PR TITLE
Fix ClearTracks

### DIFF
--- a/LESdev/Source Documented.ahk
+++ b/LESdev/Source Documented.ahk
@@ -1511,7 +1511,7 @@ WinGetTitle, WinTitle, ahk_id %guideUnderCursor%
 if(InStr(WinTitle, "Ableton") != 0){
 	Click, Right
 	sleep, 20
-	SendInput {down 12}{enter}{delete}
+	SendInput {up 8}{enter}{delete}
 }
 Return
 


### PR DESCRIPTION
Update ClearTracks (alt + x) to fix it in Ableton 11 and make it more reliable. Issue #6 