### PR TITLE
Implement ability to flip tab and shift+tab functionality

### DIFF
--- a/LESdev/Source Documented.ahk
+++ b/LESdev/Source Documented.ahk
@@ -503,6 +503,16 @@ Loop, Read, %A_ScriptDir%\settings.ini
 		}
 	addtostartup := result[2]
 	}
+	
+	if (RegExMatch(line, "fliptabfunction\s=\s") != 0){
+		result := StrSplit(line, "=", A_Space)
+		if !(result[2] = 0 or result[2] = 1){
+			msgbox % "Invalid parameter for " . Chr(34) "fliptabfunction" . Chr(34) . ". Valid parameters are: 1 and 0. The program will shut down now."
+			run, %A_ScriptDir%\settings.ini
+			exitapp
+			}
+		fliptabfunction := result[2]
+	}
 }
 
 ; alright, so this section asks the user to update the settings.ini with the one included in the package if some values are missing.
@@ -645,9 +655,10 @@ Hotkey, ^b, buplicate
 
 Hotkey, ^+h, directshyper
 
-Hotkey, Tab, PianoRoll
-
-Hotkey, LShift & Tab, SessionView
+if (fliptabfunction = 1) {
+	Hotkey, Tab, PianoRoll
+	Hotkey, LShift & Tab, SessionView
+}
 
 if(vstshortcuts = 1){
 	scaling = 1

--- a/LESdev/Source Documented.ahk
+++ b/LESdev/Source Documented.ahk
@@ -645,6 +645,10 @@ Hotkey, ^b, buplicate
 
 Hotkey, ^+h, directshyper
 
+Hotkey, Tab, PianoRoll
+
+Hotkey, LShift & Tab, SessionView
+
 if(vstshortcuts = 1){
 	scaling = 1
 	Hotkey, 1, vst1
@@ -1577,6 +1581,22 @@ Loop %windows%
 ;}
 SetTitleMatchMode, 2
 Return
+
+PianoRoll:
+MouseGetPos,,,guideUnderCursor
+WinGetTitle, WinTitle, ahk_id %guideUnderCursor%
+if(InStr(WinTitle, "Ableton") != 0){
+	send {LShift down}{Tab}{LShift up}
+}
+return
+
+SessionView:
+MouseGetPos,,,guideUnderCursor
+WinGetTitle, WinTitle, ahk_id %guideUnderCursor%
+if(InStr(WinTitle, "Ableton") != 0){
+	send {Tab}
+}
+return
 
 ;safeautomationopen: ;depricated feature
 ;if (pressingshit = 1){

--- a/LESdev/settings.ini
+++ b/LESdev/settings.ini
@@ -80,7 +80,7 @@ smarticon = 0
 ;	Auto-hides the tray icon when Ableton Live is not in use.
 ;	LES will *still* be running in the background!! It's just here for those of you who hate tray clutter.
 
-enabledebug = 0
+enabledebug = 1
 ;	allows you to view the AHK console log and keycodes.
 
 addtostartup = 0

--- a/LESdev/settings.ini
+++ b/LESdev/settings.ini
@@ -85,3 +85,6 @@ enabledebug = 1
 
 addtostartup = 0
 ;	causes the script to launch on startup
+
+fliptabfunction = 0
+;	flips the tab and shift+tab functions to have tab switch between piano roll and device view and shift+tab switch between arrangement and session view.

--- a/LESdev/settings.ini
+++ b/LESdev/settings.ini
@@ -80,7 +80,7 @@ smarticon = 0
 ;	Auto-hides the tray icon when Ableton Live is not in use.
 ;	LES will *still* be running in the background!! It's just here for those of you who hate tray clutter.
 
-enabledebug = 1
+enabledebug = 0
 ;	allows you to view the AHK console log and keycodes.
 
 addtostartup = 0


### PR DESCRIPTION
Adds the ability to flip the tab and shift+tab functions to have tab switch between piano roll and device view and shift+tab switch between arrangement and session view as requested in issue #3.